### PR TITLE
fix(resource): improve YAML mapping-error suggestion for nested permissions (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Discovery error suggestion for `mapping values are not allowed` now covers both common causes** — when an agent's frontmatter contained a granular permission block written on a single line (e.g. `bash: "*": ask`), the YAML parser failed with `mapping values are not allowed in this context` and `aimgr repo sync` skipped the agent. The auto-generated suggestion only mentioned quoting the description field, leaving users guessing what to fix; the suggestion now explicitly covers both the unquoted-value case and the nested-mapping-on-one-line case (with a corrected `permissions:` example), so the failure surfaces actionable guidance instead of feeling silent. Fixes [#12](https://github.com/dynatrace-oss/ai-config-manager/issues/12).
+
 ## [3.9.0] - 2026-04-18
 
 ### Added

--- a/cmd/repo_sync_test.go
+++ b/cmd/repo_sync_test.go
@@ -2597,6 +2597,35 @@ func TestRunSync_JSONOutputIncludesDiscoveryIssues(t *testing.T) {
 	}
 }
 
+// TestRunSync_DiscoveryIssueSuggestionMentionsNestedMapping is a regression test
+// for https://github.com/dynatrace-oss/ai-config-manager/issues/12. When a user
+// writes a granular permission block like `bash: "*": ask` (intending a nested
+// mapping but on a single line) the YAML parser fails with
+// "mapping values are not allowed in this context" and the agent silently fails
+// to load. The discovery-issue suggestion must explicitly tell the user that
+// nested mappings need their own indented lines, not just hint at quoting.
+func TestRunSync_DiscoveryIssueSuggestionMentionsNestedMapping(t *testing.T) {
+	sourceDir := createSourceWithMalformedAgentAndValidCommand(t)
+	_, cleanup := setupTestManifest(t, []*repomanifest.Source{{Name: "broken-source", Path: sourceDir}})
+	defer cleanup()
+
+	output := captureOutput(t, func() {
+		if err := runSync(syncCmd, []string{}); err != nil {
+			t.Fatalf("runSync failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output.Stdout, "agents/broken-agent.md") {
+		t.Fatalf("expected malformed agent path in sync output, got:\n%s", output.Stdout)
+	}
+	if !strings.Contains(output.Stdout, "indented lines") {
+		t.Fatalf("expected suggestion to mention nested-mapping fix ('indented lines'), got:\n%s", output.Stdout)
+	}
+	if !strings.Contains(output.Stdout, "permissions:") {
+		t.Fatalf("expected suggestion to include a corrected 'permissions:' example, got:\n%s", output.Stdout)
+	}
+}
+
 func TestRunSync_TableModePrintsImmediateStartupBanner(t *testing.T) {
 	source1 := createTestSource(t)
 	sources := []*repomanifest.Source{{Name: "test-source-1", Path: source1}}

--- a/pkg/resource/errors.go
+++ b/pkg/resource/errors.go
@@ -89,7 +89,14 @@ func SuggestFix(err error) string {
 	// YAML parsing errors
 	if strings.Contains(errMsg, "mapping values are not allowed") ||
 		strings.Contains(errMsg, "did not find expected key") {
-		return "Quote the description field if it contains colons or special characters (e.g., description: \"My tool: a helper\")"
+		return "YAML mapping error: an unquoted ':' inside a scalar value, " +
+			"or a nested mapping written on the same line as its parent key.\n" +
+			"  Fixes:\n" +
+			"    - Quote values containing ':' (e.g., description: \"My tool: a helper\")\n" +
+			"    - Put nested mappings on their own indented lines, e.g.:\n" +
+			"        permissions:\n" +
+			"          bash:\n" +
+			"            \"*\": ask"
 	}
 
 	if strings.Contains(errMsg, "yaml: unmarshal errors") {

--- a/pkg/resource/errors_test.go
+++ b/pkg/resource/errors_test.go
@@ -76,7 +76,12 @@ func TestSuggestFix(t *testing.T) {
 		{
 			name:      "YAML mapping error",
 			err:       errors.New("yaml: line 2: mapping values are not allowed"),
-			wantMatch: "Quote the description field",
+			wantMatch: "Quote values containing ':'",
+		},
+		{
+			name:      "YAML mapping error mentions nested-mapping fix (issue #12)",
+			err:       errors.New("yaml: line 3: mapping values are not allowed in this context"),
+			wantMatch: "indented lines",
 		},
 		{
 			name:      "name mismatch",


### PR DESCRIPTION
## Summary

When an agent's frontmatter contains a granular permission block on a single line, like the example from #12

```yaml
permissions:
  bash: "*": ask
  edit: "*": ask
```

the YAML parser fails with `mapping values are not allowed in this context`, the agent is dropped during discovery, and `aimgr repo sync` removes it from the repo. The auto-generated suggestion in `pkg/resource.SuggestFix` only mentioned quoting the description field, so users hit a colon-related YAML error and get advice about a field they didn't touch - the failure feels silent

## Change

- rewrite the suggestion in `pkg/resource.SuggestFix` so it covers both common causes of `mapping values are not allowed`: an unquoted `:` inside a scalar value, and a nested mapping written on the same line as its parent key
- include a corrected `permissions:` example so the fix is directly applicable

After the change discovery output looks like:

```
⚠ Discovery Issues for source 'broken-source' (1):

  ✗ agents/broken-agent.md
    Error: agent 'broken-agent' field 'frontmatter' in /...: failed to parse frontmatter YAML: yaml: line 3: mapping values are not allowed in this context
    → Suggestion: YAML mapping error: an unquoted ':' inside a scalar value, or a nested mapping written on the same line as its parent key.
  Fixes:
    - Quote values containing ':' (e.g., description: "My tool: a helper")
    - Put nested mappings on their own indented lines, e.g.:
        permissions:
          bash:
            "*": ask
```

## Test plan

- updated existing `TestSuggestFix` case to assert the new wording, plus a new case that asserts the nested-mapping fix is mentioned
- new integration test `TestRunSync_DiscoveryIssueSuggestionMentionsNestedMapping` runs the full sync flow against the existing malformed-agent fixture and asserts the suggestion text reaches stdout
- `TestRunSync_TableOutputPrintsDiscoveryIssuesForMalformedResources`, `TestRunSync_JSONOutputIncludesDiscoveryIssues`, `TestInstallFromManifest_BootstrapPrintsDiscoveryIssuesForMalformedResources` still pass (the install golden-file normalizer only keeps lines containing `mapping values are not allowed in this context`, so the new suggestion lines don't affect it)

```
go build ./...
go vet ./...
go test -short ./pkg/resource/ ./cmd/
go test -tags=integration -run "TestRunSync_Discovery|TestInstallFromManifest_BootstrapPrints" ./cmd/
```

Fixes #12
